### PR TITLE
Proof-of-concept: Allow Jekyll to organize pages automatically (PoC)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
       - name: "Set up Python"
         uses: "actions/setup-python@v2"
       - name: "Run pre-commit"
-        uses: pre-commit/action@v2.0.0
+        uses: "pre-commit/action@v2.0.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
+repos:
 - repo: git://github.com/igorshubovych/markdownlint-cli
-  rev: v0.25.0
+  rev: v0.27.1
   hooks:
   - id: markdownlint

--- a/0000-use-markdown-architectural-decision-records.md
+++ b/0000-use-markdown-architectural-decision-records.md
@@ -1,6 +1,11 @@
-# Use Markdown Architectural Decision Records
-
-* Status: accepted
+---
+layout: page
+status: accepted
+adr: "0000"
+title: Use Markdown Architectural Decision Records
+deciders:
+date:
+---
 
 ## Context and problem statement
 

--- a/0001-unification-of-mets-creation.md
+++ b/0001-unification-of-mets-creation.md
@@ -1,6 +1,11 @@
-# Unification of METS creation
-
-* Status: accepted
+---
+layout: page
+status: accepted
+adr: "0001"
+title: Unification of METS creation
+deciders:
+date:
+---
 
 Note: this record uses a different structure based on
 [Michael Nygard's blog post][nygard].

--- a/0002-json-encoded-workflow.md
+++ b/0002-json-encoded-workflow.md
@@ -1,6 +1,11 @@
-# JSON-encoded workflow
-
-* Status: accepted
+---
+layout: page
+status: accepted
+adr: "0002"
+title: JSON-encoded workflow
+deciders:
+date:
+---
 
 ## Context and problem statement
 

--- a/0003-black-code-formatter.md
+++ b/0003-black-code-formatter.md
@@ -1,6 +1,11 @@
-# Black code formatter
-
-* Status: accepted
+---
+layout: page
+status: accepted
+adr: "0003"
+title: Black code formatter
+deciders:
+date:
+---
 
 ## Context and problem statement
 

--- a/0004-isort-import-ordering.md
+++ b/0004-isort-import-ordering.md
@@ -1,6 +1,11 @@
-# Isort Import Formatting
-
-* Status: proposed
+---
+layout: page
+status: proposed
+adr: "0004"
+title: Isort Import Formatting
+deciders:
+date:
+---
 
 ## Context and problem statement
 

--- a/0005-new-api-endpoint-for-csv-validation.md
+++ b/0005-new-api-endpoint-for-csv-validation.md
@@ -1,7 +1,11 @@
-# New API endpoint for CSV validation
-
-* Status: proposed
-* Date: 2018-03-28
+---
+layout: page
+status: accepted
+adr: "0005"
+title: New API endpoint for CSV validation
+deciders:
+date: 2018-03-28
+---
 
 ## Context and problem statement
 

--- a/0006-use-bagit-to-package-transfers.md
+++ b/0006-use-bagit-to-package-transfers.md
@@ -1,8 +1,11 @@
-# Use BagIt to package transfers
-
-* Status: proposed
-* Deciders: Justin Simpson, Jesús García Crespo, Peter Van Garderen
-* Date: 2019-01-01
+---
+layout: page
+status: accepted
+adr: "0006"
+title: Use BagIt to package transfers
+deciders: Justin Simpson, Jesús García Crespo, Peter Van Garderen
+date: 2019-01-01
+---
 
 ## Context and problem statement
 

--- a/0007-python3.md
+++ b/0007-python3.md
@@ -1,11 +1,11 @@
-# Refactor to Python 3
-
-* Status: proposed
-* Deciders: Justin Simpson, Sarah Romkey, Darren Craze, Joel Simpson, David
-  Juhasz, Jesús García Crespo, Pieter Van Garderen, Sara Allain, Ashley Blewer,
-  Santiago Rodríguez Collazo, Miguel Angel Medinilla Luque, José Raddaoui Marín,
-  Cole Maclean, Ross Spencer, Douglas Cerna.
-* Date: 2019-07-22
+---
+layout: page
+status: accepted
+adr: "0007"
+title: Refactor to Python 3
+deciders: "Justin Simpson, Sarah Romkey, Darren Craze, Joel Simpson, David Juhasz, Jesús García Crespo, Pieter Van Garderen, Sara Allain, Ashley Blewer, Santiago Rodríguez Collazo, Miguel Angel Medinilla Luque, José Raddaoui Marín, Cole Maclean, Ross Spencer, Douglas Cerna."
+date: 2019-07-22
+---
 
 ## Context and problem statement
 

--- a/0008-remove-quarantine.md
+++ b/0008-remove-quarantine.md
@@ -1,8 +1,11 @@
-# Remove quarantine
-
-* Status: accepted
-* Deciders: Jesús García Crespo, Sarah Romkey
-* Date: 2019-10-13
+---
+layout: page
+status: accepted
+adr: "0008"
+title: Remove quarantine
+deciders: Jesús García Crespo, Sarah Romkey
+date: 2019-10-13
+---
 
 ## Context and problem statement
 

--- a/0009-unification-of-api-handling-in-am.md
+++ b/0009-unification-of-api-handling-in-am.md
@@ -1,8 +1,11 @@
-# Use AMClient (Archivematica API Client) for API calls in Archivematica
-
-* Status: proposed
-* Deciders: Artefactual Systems Inc.
-* Date: 2019-10-25
+---
+layout: page
+status: proposed
+adr: "0009"
+title: Use AMClient (Archivematica API Client) for API calls in Archivematica
+deciders: Artefactual Systems Inc.
+date: 2019-10-25
+---
 
 ## Context and problem statement
 

--- a/0010-archivematica-original-design-principles.md
+++ b/0010-archivematica-original-design-principles.md
@@ -1,11 +1,11 @@
-# Archivematica original design principles
-
-* Status: accepted
-
-## Authors
-
-* Peter Van Garderen
-* Evelyn McLellan
+---
+layout: page
+status: accepted
+adr: "0010"
+title: Archivematica original design principles
+deciders: Peter Van Garderen, Evelyn McLellan
+date: 2021-06-09
+---
 
 ## Context and problem statement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,7 @@
-# Contributing
+---
+layout: page
+title: Contributing
+---
 
 ## When to submit an ADR
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ If you’re looking for a place to file a bug, enhancement, or non-architectural
 feature, please visit the [Issues](https://github.com/archivematica/Issues)
 repo.
 
-Information on creating new ADRs can be found in
-[CONTRIBUTING.md](CONTRIBUTING.md).
+Information on creating new ADRs can be found in the [CONTRIBUTING] document.
 
-A list of currently accepted records can be found in the
-[Accepted log](accepted-log.md).
+A list of currently accepted records can be found in the [Accepted log].
+
+[CONTRIBUTING]: CONTRIBUTING.md
+[Accepted log]: accepted-log.md

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,13 @@
   <body>
     {% include header.html %}
     <div class="container">
+      <h1>{{ page.title }}</h1>
+      {% if page.status %}
+        <ul>
+          <li>Status: {{ page.status }}</li>
+          <li>Deciders: {{ page.deciders }}</li>
+          <li>Date: {{ page.date }}</li>
+        </ul>{% endif %}
       {{ content }}
     </div>
     {% include footer.html %}

--- a/accepted-log.md
+++ b/accepted-log.md
@@ -1,26 +1,20 @@
-# Accepted log
+---
+title: Accepted log
+---
 
 ## Currently accepted records
 
-<!-- markdownlint-disable MD013 -->
+{% assign subpage = site.pages | where: 'status', 'accepted' %}
 
-- [ADR-0000](0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
-- [ADR-0001](0001-unification-of-mets-creation.md) - Unification of METS Creation
-- [ADR-0002](0002-json-encoded-workflow.md) - JSON-encoded workflow
-- [ADR-0003](0003-black-code-formatter.md) - Black code formatter
-- [ADR-0004](0004-isort-import-ordering.md) - isort import formatting
-- [ADR-0005](0005-new-api-endpoint-for-csv-validation.md) - New API endpoint for CSV validation
-- [ADR-0006](0006-use-bagit-to-package-transfers.md) - Use BagIt to package transfers
-- [ADR-0007](0007-python3.md) - Python 3
-- [ADR-0008](0008-remove-quarantine.md) - Remove quarantine
-- [ADR-0009](0009-unification-of-api-handling-in-am.md) - Use AMClient (Archivematica API Client) for API calls in Archivematica
-- [ADR-0010](0010-archivematica-original-design-principles.md) - Archivematica original design principles
+{% for item in subpage %}* [ADR-{{ item.adr }}]({{ item.url}}) - {{ item.title }}
+{% endfor %}
 
-<!-- adrlogstop -->
+## Currently proposed records
 
-<!-- markdownlint-enable MD013 -->
+{% assign subpage = site.pages | where: 'status', 'proposed' %}
 
-<!-- ## Proposed records -->
+{% for item in subpage %}* [ADR-{{ item.adr }}]({{ item.url}}) - {{ item.title }}
+{% endfor %}
 
 <!-- ## Superseded records -->
 

--- a/template.md
+++ b/template.md
@@ -1,11 +1,12 @@
-# [short title of solved problem and solution]
-
-* Status: [proposed | rejected | accepted | deprecated | … | superseded by
-  [ADR-0005](0005-example.md)] <!-- optional -->
-* Deciders: [list everyone involved in the decision] <!-- optional -->
-* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
-
-Technical story: [description | ticket/issue URL] <!-- optional -->
+---
+layout: page
+adr: [adr-number]
+title: [short title of solved problem and solution]
+status: [proposed | rejected | accepted | deprecated | … | superseded by]
+deciders: [ <!-- optional --> list everyone involved in the decision <!-- optional --> ]
+date: [ <!-- optional --> YYYY-MM-DD when the decision was last updated <!-- optional --> ]
+technical-story: [ <!-- optional --> description | ticket/issue URL <!-- optional --> ]
+---
 
 ## Context and problem statement
 


### PR DESCRIPTION
This commit uses Jekyll's mechanics to help us to conditionally organize pages in the accepted log based on those records that are either proposed or accepted. Front-matter has been updated per-page as well as information in the template. The commit happens to fix a small issue whereby CONTRIBUTING.md wasn't rendering, but there is no reason it shouldn't. Finally, because of this change, any updates to ADRs do not also need to be added manually to the accepted log. New records will be picked-up by the index and displayed. Maintenance should be easier this way.

To try locally: `bundle exec jekyll serve`

Example output:

![image](https://user-images.githubusercontent.com/1880412/86962615-34b42180-c131-11ea-8f69-1f80b2f49050.png)

**Questions for the team:**

* Need to organize template better if this approach is used.
* Does the front-matter work for us this way? Additional conditionals might be needed for fields we're really happy with keeping empty. We see gaps for example in early records:
* Process likely needs updating as we no longer need to update things in two-places adding a record.
* Markfown-lint rules might very well need changing, see, build failures!

![image](https://user-images.githubusercontent.com/1880412/86962811-7c3aad80-c131-11ea-8d55-af42aea5f0bb.png)
